### PR TITLE
Implement strict decoding

### DIFF
--- a/derivation/src/main/scala/io/circe/magnolia/configured/Configuration.scala
+++ b/derivation/src/main/scala/io/circe/magnolia/configured/Configuration.scala
@@ -19,12 +19,15 @@ import java.util.regex.Pattern
   *                                  formatting or case changes.
   *                                  If there are collisions in transformed constructor names, an exception will be thrown
   *                                  during derivation (runtime)
+  * @param strictDecoding When true, raises a decoding error when there are any extraneous fields in the given JSON
+  *                       that aren't present in the case class.
   */
 final case class Configuration(
   transformMemberNames: String => String,
   transformConstructorNames: String => String,
   useDefaults: Boolean,
-  discriminator: Option[String]
+  discriminator: Option[String],
+  strictDecoding: Boolean = false
 ) {
   def withSnakeCaseMemberNames: Configuration = copy(
     transformMemberNames = Configuration.snakeCaseTransformation
@@ -44,6 +47,7 @@ final case class Configuration(
 
   def withDefaults: Configuration = copy(useDefaults = true)
   def withDiscriminator(discriminator: String): Configuration = copy(discriminator = Some(discriminator))
+  def withStrictDecoding: Configuration = copy(strictDecoding = true)
 }
 
 final object Configuration {

--- a/tests/src/test/scala/io/circe/magnolia/configured/ConfiguredAutoDerivedEquivalenceSuite.scala
+++ b/tests/src/test/scala/io/circe/magnolia/configured/ConfiguredAutoDerivedEquivalenceSuite.scala
@@ -134,6 +134,7 @@ class ConfiguredAutoDerivedEquivalenceSuite extends CirceSuite {
   testWithConfiguration("with snake case configuration", Configuration.default.withSnakeCaseConstructorNames.withSnakeCaseMemberNames)
   testWithConfiguration("with useDefault = true", Configuration.default.copy(useDefaults = true))
   testWithConfiguration("with discriminator", Configuration.default.copy(discriminator = Some("type")))
+  testWithConfiguration("with strict", Configuration.default.copy(strictDecoding = true))
 
   "If a sealed trait subtype has explicit Encoder instance that doesn't encode to a JsonObject, the derived encoder" should
     s"wrap it with type constructor even when discriminator is specified by the configuration" in {

--- a/tests/src/test/scala/io/circe/magnolia/configured/ConfiguredSemiautoDerivedEquivalenceSuite.scala
+++ b/tests/src/test/scala/io/circe/magnolia/configured/ConfiguredSemiautoDerivedEquivalenceSuite.scala
@@ -126,6 +126,7 @@ class ConfiguredSemiautoDerivedEquivalenceSuite extends CirceSuite {
   testWithConfiguration("with snake case configuration", Configuration.default.withSnakeCaseConstructorNames.withSnakeCaseMemberNames)
   testWithConfiguration("with useDefault = true", Configuration.default.copy(useDefaults = true))
   testWithConfiguration("with discriminator", Configuration.default.copy(discriminator = Some("type")))
+  testWithConfiguration("with strict", Configuration.default.copy(strictDecoding = true))
 
   "If a sealed trait subtype has explicit Encoder instance that doesn't encode to a JsonObject, the derived encoder" should
     s"wrap it with type constructor even when discriminator is specified by the configuration" in {


### PR DESCRIPTION
Implements support for configured strict decoding like what https://github.com/circe/circe-generic-extras supports. When enabled, the decoder will raise an error if there are extraneous fields in the JSON that aren't present in the case class which is helpful for clients to know that they've submitted an incorrect field.